### PR TITLE
Replace shell script with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+SRCFILES := todo.cpp
+
+build:
+	g++ -o todo ${SRCFILES}
+
+install:
+	cp todo /usr/bin/
+
+clean:
+	rm -rf todo
+	rm -rf ~/.config/todo
+
+uninstall:
+	rm /usr/bin/todo

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ Simple command line todo for Linux (just like the other 3000 of these)
 - g++ or any other c++ compiler
 
 # setup
-I made a `setup.sh` file that compiles the file for you, makes some folders for data and moves the file to /usr/bin.
+Standard makefile procedure
 
-To run it:
+`make` to compile it
 
-`chmod +x setup.sh`
+`make install` to install the file to /usr/bin (you'll need root privileges to run with sudo/doas)
 
-`./setup.sh`
+`make clean` to remove any binaries in the source folder and residual data (this will clear all your todo lists)
+
+`make uninstall` to uninstall from /usr/bin (you'll need root privileges again)
 
 # commands
 Current commands:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Standard makefile procedure
 
 `make` to compile it
 
-`make install` to install the file to /usr/bin (you'll need root privileges to run with sudo/doas)
+`make install` to install the file to /usr/bin (you'll need root privileges so it run with sudo/doas)
 
 `make clean` to remove any binaries in the source folder and residual data (this will clear all your todo lists)
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,0 @@
- g++ -o todo todo.cpp
- mkdir -p ~/.config/todo/
- sudo mv todo /usr/bin/


### PR DESCRIPTION
How dare you use a shell script to compile and install a piece of software? (ignore pinEApple-linux please that's a different story)

Also this script doesn't create the folder in ~/.config/todo because there was no clean way of doing it and ideally you'd do that in the todo program itself anyway. Just implement a check if the folder exists and create it if it doesn't. Shouldn't be too difficult with something like std::filesystem.